### PR TITLE
Drop `composer/installers` requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
     ],
     "require": {
         "php": ">=7.1",
-        "composer/installers": "^1.0",
         "koodimonni/composer-dropin-installer": "^1.2"
     },
     "require-dev": {


### PR DESCRIPTION
It should be require at root project level

Fix #47